### PR TITLE
Add Flash to Black when Taking Picture

### DIFF
--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -89,7 +89,7 @@ public final class ImageScannerController: UINavigationController {
     }
     
     internal func flashToBlack() {
-        self.view.bringSubview(toFront: blackFlashView)
+        view.bringSubview(toFront: blackFlashView)
         blackFlashView.isHidden = false
         let flashDuration = DispatchTime.now() + 0.05
         DispatchQueue.main.asyncAfter(deadline: flashDuration) {

--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -75,10 +75,10 @@ public final class ImageScannerController: UINavigationController {
     
     private func setupConstraints() {
         let blackFlashViewConstraints = [
-            blackFlashView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             blackFlashView.topAnchor.constraint(equalTo: view.topAnchor),
-            view.trailingAnchor.constraint(equalTo: blackFlashView.trailingAnchor),
-            view.bottomAnchor.constraint(equalTo: blackFlashView.bottomAnchor)
+            blackFlashView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            view.bottomAnchor.constraint(equalTo: blackFlashView.bottomAnchor),
+            view.trailingAnchor.constraint(equalTo: blackFlashView.trailingAnchor)
         ]
         
         NSLayoutConstraint.activate(blackFlashViewConstraints)

--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -47,11 +47,22 @@ public final class ImageScannerController: UINavigationController {
     
     // MARK: - Life Cycle
     
+    /// A black UIView, used to quickly display a black screen when the shutter button is presseed.
+    internal let blackFlashView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     public required init() {
         let scannerViewController = ScannerViewController()
         super.init(rootViewController: scannerViewController)
         navigationBar.tintColor = .black
         navigationBar.isTranslucent = false
+        self.view.addSubview(blackFlashView)
+        setupConstraints()
     }
     
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -62,8 +73,28 @@ public final class ImageScannerController: UINavigationController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private func setupConstraints() {
+        let blackFlashViewConstraints = [
+            blackFlashView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            blackFlashView.topAnchor.constraint(equalTo: view.topAnchor),
+            view.trailingAnchor.constraint(equalTo: blackFlashView.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: blackFlashView.bottomAnchor)
+        ]
+        
+        NSLayoutConstraint.activate(blackFlashViewConstraints)
+    }
+    
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
+    }
+    
+    internal func flashToBlack() {
+        self.view.bringSubview(toFront: blackFlashView)
+        blackFlashView.isHidden = false
+        let flashDuration = DispatchTime.now() + 0.05
+        DispatchQueue.main.asyncAfter(deadline: flashDuration) {
+            self.blackFlashView.isHidden = true
+        }
     }
     
 }

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -116,6 +116,7 @@ final class ScannerViewController: UIViewController {
     
     @objc private func captureImage(_ sender: UIButton) {
         (navigationController as? ImageScannerController)?.flashToBlack()
+        shutterButton.isUserInteractionEnabled = false
         captureSessionManager?.capturePhoto()
     }
     

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -115,6 +115,7 @@ final class ScannerViewController: UIViewController {
     // MARK: - Actions
     
     @objc private func captureImage(_ sender: UIButton) {
+        (navigationController as? ImageScannerController)?.flashToBlack()
         captureSessionManager?.capturePhoto()
     }
     


### PR DESCRIPTION
On iOS, the screen flashes to black when a picture is being taken.
With this PR, the same behavior happens in WeScan.