### PR TITLE
Add auto rotate and Vision support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
-    pod 'WeScan', '~> 1.0.0'
+    pod 'WeScan', '>= 0.9'
 end
 ```
 
@@ -72,7 +72,7 @@ $ pod install
 To integrate **WeScan** into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "WeTransfer/WeScan" >= 1.00
+github "WeTransfer/WeScan" >= 0.9
 ```
 
 Run `carthage update` to build the framework and drag the built `WeScan.framework` into your Xcode project.

--- a/WeScan.xcodeproj/project.pbxproj
+++ b/WeScan.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		A1F22EA3202DAA74001723AD /* RectangleFeaturesFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F22EA2202DAA74001723AD /* RectangleFeaturesFunnel.swift */; };
 		A1F22EA5202DB3AA001723AD /* CGPoint+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F22EA4202DB3AA001723AD /* CGPoint+Utils.swift */; };
 		A1F22ECE2031937E001723AD /* EditScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F22ECD2031937E001723AD /* EditScanViewController.swift */; };
+		B99E4B9A210B00A400976BC5 /* VNRectangleObservation+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99E4B99210B00A400976BC5 /* VNRectangleObservation+Utils.swift */; };
 		C31DD8A320C087D80072D439 /* ZoomGestureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31DD8A220C087D80072D439 /* ZoomGestureController.swift */; };
 		C3789C9B20CC69AD001B423F /* QuadrilateralViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3789C9A20CC69AD001B423F /* QuadrilateralViewTests.swift */; };
 		C3E2EB8E20B8970800A42E58 /* UIImage+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2EB8D20B8970800A42E58 /* UIImage+Utils.swift */; };
@@ -135,6 +136,7 @@
 		A1F22EA2202DAA74001723AD /* RectangleFeaturesFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFeaturesFunnel.swift; sourceTree = "<group>"; };
 		A1F22EA4202DB3AA001723AD /* CGPoint+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPoint+Utils.swift"; sourceTree = "<group>"; };
 		A1F22ECD2031937E001723AD /* EditScanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditScanViewController.swift; sourceTree = "<group>"; };
+		B99E4B99210B00A400976BC5 /* VNRectangleObservation+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VNRectangleObservation+Utils.swift"; sourceTree = "<group>"; };
 		C31DD8A220C087D80072D439 /* ZoomGestureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomGestureController.swift; sourceTree = "<group>"; };
 		C3789C9A20CC69AD001B423F /* QuadrilateralViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuadrilateralViewTests.swift; sourceTree = "<group>"; };
 		C3E2EB8D20B8970800A42E58 /* UIImage+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Utils.swift"; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 			children = (
 				A1D4BD14202C6CC000FCDDEC /* Array+Utils.swift */,
 				A1F22EA0202C8E24001723AD /* CIRectangleFeature+Utils.swift */,
+				B99E4B99210B00A400976BC5 /* VNRectangleObservation+Utils.swift */,
 				A11C5CDA20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift */,
 				A1F22EA4202DB3AA001723AD /* CGPoint+Utils.swift */,
 				A1DF90F12035992A00841A11 /* CGAffineTransform+Utils.swift */,
@@ -524,6 +527,7 @@
 				A1DF90A420331A0B00841A11 /* RectangleDetector.swift in Sources */,
 				A1DF90F62037187500841A11 /* UIImage+Orientation.swift in Sources */,
 				A1F22E99202C7B66001723AD /* QuadrilateralView.swift in Sources */,
+				B99E4B9A210B00A400976BC5 /* VNRectangleObservation+Utils.swift in Sources */,
 				A194E97220431DD7003493E2 /* ReviewViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -699,7 +703,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 67V847367C;
+				DEVELOPMENT_TEAM = 74N8K5J2N7;
 				INFOPLIST_FILE = WeScanSampleProject/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -716,7 +720,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 67V847367C;
+				DEVELOPMENT_TEAM = 74N8K5J2N7;
 				INFOPLIST_FILE = WeScanSampleProject/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/WeScan/Common/Quadrilateral.swift
+++ b/WeScan/Common/Quadrilateral.swift
@@ -61,6 +61,37 @@ public struct Quadrilateral: Transformable {
         return quadrilateral
     }
     
+    /// Checks whether the quadrilateral is withing a given distance of another quadrilateral.
+    ///
+    /// - Parameters:
+    ///   - distance: The distance (threshold) to use for the condition to be met.
+    ///   - rectangleFeature: The other rectangle to compare this instance with.
+    /// - Returns: True if the given rectangle is within the given distance of this rectangle instance.
+    func isWithin(_ distance: CGFloat, ofRectangleFeature rectangleFeature: Quadrilateral) -> Bool {
+        
+        let topLeftRect = topLeft.surroundingSquare(withSize: distance)
+        if !topLeftRect.contains(rectangleFeature.topLeft) {
+            return false
+        }
+        
+        let topRightRect = topRight.surroundingSquare(withSize: distance)
+        if !topRightRect.contains(rectangleFeature.topRight) {
+            return false
+        }
+        
+        let bottomRightRect = bottomRight.surroundingSquare(withSize: distance)
+        if !bottomRightRect.contains(rectangleFeature.bottomRight) {
+            return false
+        }
+        
+        let bottomLeftRect = bottomLeft.surroundingSquare(withSize: distance)
+        if !bottomLeftRect.contains(rectangleFeature.bottomLeft) {
+            return false
+        }
+        
+        return true
+    }
+    
     /// Reorganizes the current quadrilateal, making sure that the points are at their appropriate positions. For example, it ensures that the top left point is actually the top and left point point of the quadrilateral.
     mutating func reorganize() {
         let points = [topLeft, topRight, bottomRight, bottomLeft]

--- a/WeScan/Common/RectangleDetector.swift
+++ b/WeScan/Common/RectangleDetector.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 WeTransfer. All rights reserved.
 //
 
+import Vision
 import Foundation
 import AVFoundation
 
@@ -17,18 +18,62 @@ struct RectangleDetector {
     /// - Parameters:
     ///   - image: The image to detect rectangles on.
     /// - Returns: The biggest detected rectangle on the image.
-    static func rectangle(forImage image: CIImage) -> CIRectangleFeature? {
-        let rectangleDetector = CIDetector(ofType: CIDetectorTypeRectangle, context: CIContext(options: nil), options: [CIDetectorAccuracy: CIDetectorAccuracyHigh])
-        
-        guard let rectangleFeatures = rectangleDetector?.features(in: image) as? [CIRectangleFeature] else {
-            return nil
+    static func rectangle(forImage image: CIImage, completion: @escaping ((Quadrilateral?) -> ())) {
+        if #available(iOS 11.0, *) {
+            let imageRequestHandler = VNImageRequestHandler(ciImage: image, options: [:])
+            var biggestRectangle: Quadrilateral? = nil
+            
+            // Create the rectangle request, and, if found, return the biggest rectangle (else return nothing).
+            let rectangleDetectionRequest: VNDetectRectanglesRequest = {
+                let rectDetectRequest = VNDetectRectanglesRequest(completionHandler: { (request, error) in
+                    if error == nil {
+                        guard let results = request.results as? [VNRectangleObservation] else { return }
+                        guard let biggest = results.count > 1 ? results.biggest() : results.first else { return }
+                        
+                        let transform = CGAffineTransform.identity
+                            .scaledBy(x: 1, y: -1)
+                            .translatedBy(x: 0, y: -image.extent.size.height)
+                            .scaledBy(x: image.extent.size.width, y: image.extent.size.height)
+                        
+                        biggestRectangle = Quadrilateral(topLeft: biggest.topLeft.applying(transform), topRight: biggest.topRight.applying(transform), bottomRight: biggest.bottomRight.applying(transform), bottomLeft: biggest.bottomLeft.applying(transform))
+                        completion(biggestRectangle)
+                        
+                    } else { completion(nil) }
+                })
+                rectDetectRequest.minimumConfidence = 0.7 // Be confident.
+                rectDetectRequest.maximumObservations = 8
+                return rectDetectRequest
+            }()
+            
+            // Send the requests to the request handler.
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try imageRequestHandler.perform([rectangleDetectionRequest])
+                } catch let error as NSError {
+                    print("Failed to perform image request: \(error)")
+                    completion(nil)
+                    return
+                }
+            }
+            
+        } else {
+            let rectangleDetector = CIDetector(ofType: CIDetectorTypeRectangle, context: CIContext(options: nil), options: [CIDetectorAccuracy: CIDetectorAccuracyHigh])
+            
+            guard let rectangleFeatures = rectangleDetector?.features(in: image) as? [CIRectangleFeature] else {
+                completion(nil)
+                return
+            }
+            
+            guard let biggest = rectangleFeatures.biggest() else {
+                completion(nil)
+                return
+            }
+            
+            let biggestRectangle = Quadrilateral(rectangleFeature: biggest)
+            
+            completion(biggestRectangle)
+            
         }
-        
-        guard let biggestRectangle = rectangleFeatures.biggest() else {
-            return nil
-        }
-        
-        return biggestRectangle
     }
     
 }

--- a/WeScan/Edit/EditScanViewController.swift
+++ b/WeScan/Edit/EditScanViewController.swift
@@ -126,7 +126,7 @@ final class EditScanViewController: UIViewController {
                     let error = ImageScannerControllerError.ciImageCreation
                     imageScannerController.imageScannerDelegate?.imageScannerController(imageScannerController, didFailWithError: error)
                 }
-            return
+                return
         }
         
         let scaledQuad = quad.scale(quadView.bounds.size, image.size)

--- a/WeScan/Edit/ZoomGestureController.swift
+++ b/WeScan/Edit/ZoomGestureController.swift
@@ -42,7 +42,7 @@ final class ZoomGestureController {
         let offset = CGAffineTransform(translationX: position.x - previousPanPosition.x, y: position.y - previousPanPosition.y)
         let cornerView = quadView.cornerViewForCornerPosition(position: closestCorner)
         let draggedCornerViewCenter = cornerView.center.applying(offset)
-
+        
         quadView.moveCorner(cornerView: cornerView, atPoint: draggedCornerViewCenter)
         
         self.previousPanPosition = position
@@ -56,5 +56,5 @@ final class ZoomGestureController {
         
         quadView.highlightCornerAtPosition(position: closestCorner, with: zoomedImage)
     }
-
+    
 }

--- a/WeScan/Extensions/Array+Utils.swift
+++ b/WeScan/Extensions/Array+Utils.swift
@@ -6,12 +6,31 @@
 //  Copyright © 2018 WeTransfer. All rights reserved.
 //
 
+import Vision
 import Foundation
 
 extension Array where Element: CIRectangleFeature {
     
     /// Finds the biggest rectangle within an array of `CIRectangleFeature` objects.
     func biggest() -> CIRectangleFeature? {
+        guard count > 1 else {
+            return first
+        }
+        
+        let biggestRectangle = self.max(by: { (rect1, rect2) -> Bool in
+            return rect1.perimeter() < rect2.perimeter()
+        })
+        
+        return biggestRectangle
+    }
+    
+}
+
+@available(iOS 11.0, *)
+extension Array where Element: VNRectangleObservation {
+    
+    /// Finds the biggest rectangle within an array of `CIRectangleFeature` objects.
+    func biggest() -> VNRectangleObservation? {
         guard count > 1 else {
             return first
         }

--- a/WeScan/Extensions/VNRectangleObservation+Utils.swift
+++ b/WeScan/Extensions/VNRectangleObservation+Utils.swift
@@ -1,0 +1,20 @@
+//
+//  VNRectangleObservation+Utils.swift
+//  WeScan
+//
+//  Created by Julian Schiavo on 6/26/18.
+//  Copyright © 2018 WeTransfer. All rights reserved.
+//
+
+import Vision
+import Foundation
+
+@available(iOS 11.0, *)
+extension VNRectangleObservation {
+    
+    /// The perimeter of the quadrilateral.
+    func perimeter() -> CGFloat {
+        return (topRight.x - topLeft.x) + (topRight.y - bottomRight.y) + (bottomRight.x - bottomLeft.x) + (topLeft.y - bottomLeft.y)
+    }
+    
+}

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -15,7 +15,7 @@ final class ReviewViewController: UIViewController {
         let imageView = UIImageView()
         imageView.clipsToBounds = true
         imageView.isOpaque = true
-        imageView.image = results.scannedImage
+        imageView.image = finalImage
         imageView.backgroundColor = .black
         imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -30,11 +30,28 @@ final class ReviewViewController: UIViewController {
     }()
     
     private let results: ImageScannerResults
+    let finalImage: UIImage
     
     // MARK: - Life Cycle
     
     init(results: ImageScannerResults) {
         self.results = results
+        
+        var imageAngle: Double = 0.0
+        var rotate = true
+        switch editImageOrientation {
+        case .up:
+            rotate = false
+        case .left:
+            imageAngle = Double.pi / 2
+        case .right:
+            imageAngle = -(Double.pi / 2)
+        case .down:
+            imageAngle = Double.pi
+        default:
+            rotate = false
+        }
+        finalImage = rotate ? results.scannedImage.rotated(by: Measurement(value: imageAngle, unit: .radians))! : results.scannedImage
         
         super.init(nibName: nil, bundle: nil)
     }

--- a/WeScan/Scan/RectangleFeaturesFunnel.swift
+++ b/WeScan/Scan/RectangleFeaturesFunnel.swift
@@ -16,13 +16,13 @@ final class RectangleFeaturesFunnel {
     /// `RectangleMatch` is a class used to assign matching scores to rectangles.
     private final class RectangleMatch: NSObject {
         /// The rectangle feature object associated to this `RectangleMatch` instance.
-        let rectangleFeature: CIRectangleFeature
+        let rectangleFeature: Quadrilateral
         
         /// The score to indicate how strongly the rectangle of this instance matches other recently added rectangles.
         /// A higher score indicates that many recently added rectangles are very close to the rectangle of this instance.
         var matchingScore = 0
-
-        init(rectangleFeature: CIRectangleFeature) {
+        
+        init(rectangleFeature: Quadrilateral) {
             self.rectangleFeature = rectangleFeature
         }
         
@@ -36,7 +36,7 @@ final class RectangleFeaturesFunnel {
         ///   - rectangle: The rectangle to compare the rectangle of this instance with.
         ///   - threshold: The distance used to determinate if the rectangles match in pixels.
         /// - Returns: True if both rectangles are within the given distance of each other.
-        func matches(_ rectangle: CIRectangleFeature, withThreshold threshold: CGFloat) -> Bool {
+        func matches(_ rectangle: Quadrilateral, withThreshold threshold: CGFloat) -> Bool {
             return rectangleFeature.isWithin(threshold, ofRectangleFeature: rectangle)
         }
     }
@@ -68,8 +68,9 @@ final class RectangleFeaturesFunnel {
     ///   - rectangleFeature: The rectangle to feed to the funnel.
     ///   - currentRectangle: The currently displayed rectangle. This is used to avoid displaying very close rectangles.
     ///   - completion: The completion block called when a new rectangle should be displayed.
-    func add(_ rectangleFeature: CIRectangleFeature, currentlyDisplayedRectangle currentRectangle: CIRectangleFeature?, completion: (CIRectangleFeature) -> Void) {
-        let rectangleMatch = RectangleMatch(rectangleFeature: rectangleFeature)
+    func add(_ rectangleFeature: Quadrilateral, currentlyDisplayedRectangle currentRectangle: Quadrilateral?, completion: (Quadrilateral) -> Void) {
+        completion(rectangleFeature)
+        /*let rectangleMatch = RectangleMatch(rectangleFeature: rectangleFeature)
         rectangles.append(rectangleMatch)
         
         guard rectangles.count >= minNumberOfRectangles else {
@@ -90,7 +91,7 @@ final class RectangleFeaturesFunnel {
             bestRectangle.rectangleFeature.isWithin(matchingThreshold, ofRectangleFeature: previousRectangle) {
         } else if bestRectangle.matchingScore >= minNumberOfMatches {
             completion(bestRectangle.rectangleFeature)
-        }
+        }*/
     }
     
     /// Determines which rectangle is best to displayed.
@@ -99,7 +100,7 @@ final class RectangleFeaturesFunnel {
     /// Parameters:
     ///   - currentRectangle: The currently displayed rectangle. This is used to avoid displaying very close rectangles.
     /// Returns: The best rectangle to display given the current history.
-    private func bestRectangle(withCurrentlyDisplayedRectangle currentRectangle: CIRectangleFeature?) -> RectangleMatch? {
+    private func bestRectangle(withCurrentlyDisplayedRectangle currentRectangle: Quadrilateral?) -> RectangleMatch? {
         var bestMatch: RectangleMatch?
         
         rectangles.reversed().forEach { (rectangle) in
@@ -133,7 +134,7 @@ final class RectangleFeaturesFunnel {
     ///   - rect2: The second rectangle to compare.
     ///   - currentRectangle: The currently displayed rectangle. This is used to avoid displaying very close rectangles.
     /// - Returns: The best rectangle to display between two rectangles with the same matching score.
-    private func breakTie(between rect1: RectangleMatch, rect2: RectangleMatch, currentRectangle: CIRectangleFeature) -> RectangleMatch {
+    private func breakTie(between rect1: RectangleMatch, rect2: RectangleMatch, currentRectangle: Quadrilateral) -> RectangleMatch {
         if rect1.rectangleFeature.isWithin(matchingThreshold, ofRectangleFeature: currentRectangle) {
             return rect1
         } else if rect2.rectangleFeature.isWithin(matchingThreshold, ofRectangleFeature: currentRectangle) {


### PR DESCRIPTION
This pull request adds support for auto rotating images to Portrait on iOS 10 and above, and uses Vision instead of CoreImage to detect rectangles on iOS 11 and above.

Auto rotation has been fully tested, but Vision support may not work yet. I'd appreciate any feedback and improvements.