### PR TITLE
Append French localization and fix Xcode 10 compilation

### DIFF
--- a/WeScan.podspec
+++ b/WeScan.podspec
@@ -10,9 +10,11 @@ Pod::Spec.new do |spec|
     'Boris Emorine' => 'boris@wetransfer.com',
     'Antoine van der Lee' => 'antoine@wetransfer.com'
   }
-  spec.source           = { :git => 'https://github.com/WeTransfer/WeScan.git', :tag => 'v0.9.1' }
+  spec.source           = { :git => 'https://github.com/WeTransfer/WeScan.git', :tag => "v#{spec.version}" }
   spec.social_media_url = 'https://twitter.com/WeTransfer'
 
+  spec.swift_version = '4.0'
   spec.ios.deployment_target = '10.0'
-  spec.source_files = 'WeScan/**/*'
+  spec.source_files = 'WeScan/**/*.{h,m,swift}'
+  spec.resources = 'WeScan/**/*.strings'
 end

--- a/WeScan.xcodeproj/project.pbxproj
+++ b/WeScan.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A85F43E21611B98007938F3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A85F44021611B98007938F3 /* Localizable.strings */; };
 		A11C5B9C2046A20C005075FE /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5B9B2046A20C005075FE /* Error.swift */; };
 		A11C5CD920495EA1005075FE /* RectangleFeaturesFunnelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5CD820495EA1005075FE /* RectangleFeaturesFunnelTests.swift */; };
 		A11C5CDB20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5CDA20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift */; };
-		A1265C822045BFEB009C4D3E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A1265C812045BFEB009C4D3E /* Localizable.strings */; };
 		A14089BA204D92EA0009530F /* EditScanCornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14089B9204D92EA0009530F /* EditScanCornerView.swift */; };
 		A14089EE204EAA180009530F /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14089ED204EAA180009530F /* ArrayTests.swift */; };
 		A14089F0204EAC050009530F /* BigRectangle.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A14089EF204EAC040009530F /* BigRectangle.jpg */; };
@@ -91,10 +91,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4A85F43F21611B98007938F3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4A85F44321611BDD007938F3 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A11C5B9B2046A20C005075FE /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		A11C5CD820495EA1005075FE /* RectangleFeaturesFunnelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleFeaturesFunnelTests.swift; sourceTree = "<group>"; };
 		A11C5CDA20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVCaptureVideoOrientation+Utils.swift"; sourceTree = "<group>"; };
-		A1265C812045BFEB009C4D3E /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		A14089B9204D92EA0009530F /* EditScanCornerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditScanCornerView.swift; sourceTree = "<group>"; };
 		A14089ED204EAA180009530F /* ArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
 		A14089EF204EAC040009530F /* BigRectangle.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = BigRectangle.jpg; sourceTree = "<group>"; };
@@ -230,7 +231,7 @@
 				A1DF90F720371A0800841A11 /* Common */,
 				A1D4BCEF202C4F4100FCDDEC /* WeScan.h */,
 				A1D4BCF0202C4F4100FCDDEC /* Info.plist */,
-				A1265C812045BFEB009C4D3E /* Localizable.strings */,
+				4A85F44021611B98007938F3 /* Localizable.strings */,
 			);
 			path = WeScan;
 			sourceTree = "<group>";
@@ -413,6 +414,7 @@
 			knownRegions = (
 				en,
 				Base,
+				fr,
 			);
 			mainGroup = A1D4BCAE202C4F3800FCDDEC;
 			productRefGroup = A1D4BCB8202C4F3800FCDDEC /* Products */;
@@ -441,7 +443,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1265C822045BFEB009C4D3E /* Localizable.strings in Resources */,
+				4A85F43E21611B98007938F3 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -563,6 +565,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		4A85F44021611B98007938F3 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4A85F43F21611B98007938F3 /* en */,
+				4A85F44321611BDD007938F3 /* fr */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		A1D4BCBE202C4F3800FCDDEC /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -586,6 +597,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -645,6 +657,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/WeScan/en.lproj/Localizable.strings
+++ b/WeScan/en.lproj/Localizable.strings
@@ -1,19 +1,22 @@
 /* 
   localizable.strings
-  ScannerSampleProject
+  WeScanSampleProject
 
   Created by Boris Emorine on 2/27/18.
   Copyright © 2018 WeTransfer. All rights reserved.
 */
 
+/* The title on the navigation bar of the Scanning screen. */
+"wescan.scanning.title" = "Scanning";
+
 /* The "Next" button on the right side of the navigation bar on the Edit screen. */
-"wescan_edit_button_next" = "Next";
+"wescan.edit.button.next" = "Next";
 
 /* The title on the navigation bar of the Edit screen. */
-"wescan_edit_label_edit" = "Edit Scan";
+"wescan.edit.title" = "Edit Scan";
 
 /* The "Done" button on the right side of the navigation bar on the Review screen. */
-"wescan_review_button_done" = "Done";
+"wescan.review.button.done" = "Done";
 
 /* The title on the navigation bar of the Review screen. */
-"wescan_review_label_review" = "Review";
+"wescan.review.title" = "Review";

--- a/WeScan/fr.lproj/Localizable.strings
+++ b/WeScan/fr.lproj/Localizable.strings
@@ -7,16 +7,16 @@
 */
 
 /* The title on the navigation bar of the Scanning screen. */
-"wescan.scanning.title" = "Scanning";
+"wescan.scanning.title" = "Numériser";
 
 /* The "Next" button on the right side of the navigation bar on the Edit screen. */
-"wescan.edit.button.next" = "Next";
+"wescan.edit.button.next" = "Suivant";
 
 /* The title on the navigation bar of the Edit screen. */
-"wescan.edit.title" = "Edit Scan";
+"wescan.edit.title" = "Modifier";
 
 /* The "Done" button on the right side of the navigation bar on the Review screen. */
-"wescan.review.button.done" = "Done";
+"wescan.review.button.done" = "Terminer";
 
 /* The title on the navigation bar of the Review screen. */
-"wescan.review.title" = "Review";
+"wescan.review.title" = "Aperçu";


### PR DESCRIPTION
French localization was added to project. Based on similar processes from other apps.

And fixes were append when compiling project using CocoaPods under Xcode 10:
- `Info.plist` is now excluded from compilation
- Swift version is now set to `4.0` to avoid problem with Swift 4.2 compatibility.