### PR TITLE
Updated our CI implementation to prevent unneeded force unwraps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode9.4
 gemfile: Gemfile
 bundler_args: "--without documentation --path bundle" # Don't download documentation for gems.
 cache:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 # Needed for Fastlane & Danger
 gem 'fastlane'
 gem 'danger'
-gem 'danger-swiftlint', '~>0.13.1'
+gem 'danger-swiftlint', '0.17.4'
 gem 'danger-xcov'
 gem 'danger-xcode_summary'
 gem 'xcpretty'


### PR DESCRIPTION
Referencing the correct Swiftlint rules to not show unneeded warnings like force unwraps.

Fixes #46 