### PR TITLE
Adds missing call to super

### DIFF
--- a/WeScan/Scan/ShutterButton.swift
+++ b/WeScan/Scan/ShutterButton.swift
@@ -46,6 +46,8 @@ final class ShutterButton: UIControl {
     // MARK: - Drawing
     
     override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
         outterRingLayer.frame = rect
         outterRingLayer.path = pathForOutterRing(inRect: rect).cgPath
         outterRingLayer.fillColor = UIColor.white.cgColor


### PR DESCRIPTION
From documentation:

If you subclass UIView directly, your implementation of this method does not need to call super. However, if you are subclassing a different view class, you should call super at some point in your implementation.