### PR TITLE
Correct spelling on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Simply add the WeScan framework in the project's Embedded Binaries and Linked Fr
 
 ## Usage
 
-1. Make sure that your ViewController confirms to the `ImageScannerControllerDelegate` protocol
+### Swift
+
+1. Make sure that your view controller conforms to the `ImageScannerControllerDelegate` protocol:
 
 ```swift
 class YourViewController: UIViewController, ImageScannerControllerDelegate {


### PR DESCRIPTION
This PR corrects the spelling of `confirms` to the correct spelling `conforms` and adds the Swift header that was accidentally removed when merging #35.