### PR TITLE
Remove Xcode requirement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ It's modelled after `UIImagePickerController`, which makes it a breeze to use.
 
 - Swift 4.2
 - iOS 10.0+
-- Xcode 9.x
 
 <br>
 


### PR DESCRIPTION
We should remove the Xcode **9.x** requirement as Xcode isn't really a requirement for using WeScan, and it might be misleading.