### PR TITLE
Localization in framework/cocoapods and more

### DIFF
--- a/WeScan.xcodeproj/project.pbxproj
+++ b/WeScan.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		64D4F6D422298DBC00B07103 /* Bundle+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D4F6CC22298DBC00B07103 /* Bundle+Utils.swift */; };
 		74E27858215446C900361812 /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74E27850215446C200361812 /* FBSnapshotTestCase.framework */; };
 		74F7D034211ACBD90046AF7E /* CIRectangleDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F7D033211ACBD90046AF7E /* CIRectangleDetectorTests.swift */; };
 		74F7D036211ACBEE0046AF7E /* CaptureSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F7D035211ACBEE0046AF7E /* CaptureSessionTests.swift */; };
@@ -182,6 +183,7 @@
 
 /* Begin PBXFileReference section */
 		4A644E2221A73C2B00B20839 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		64D4F6CC22298DBC00B07103 /* Bundle+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Bundle+Utils.swift"; path = "../../../../Downloads/oiddio/Extensions/Bundle+Utils.swift"; sourceTree = "<group>"; };
 		74E27848215446C200361812 /* FBSnapshotTestCase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSnapshotTestCase.xcodeproj; path = "Submodules/ios-snapshot-test-case/FBSnapshotTestCase.xcodeproj"; sourceTree = "<group>"; };
 		74E2785B2154528300361812 /* FBSnapshotTestCase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSnapshotTestCase.xcodeproj; path = "Submodules/ios-snapshot-test-case/FBSnapshotTestCase.xcodeproj"; sourceTree = SOURCE_ROOT; };
 		74F7D033211ACBD90046AF7E /* CIRectangleDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIRectangleDetectorTests.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 			isa = PBXGroup;
 			children = (
 				A1D4BD14202C6CC000FCDDEC /* Array+Utils.swift */,
+				64D4F6CC22298DBC00B07103 /* Bundle+Utils.swift */,
 				A11C5CDA20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift */,
 				A1F22EA4202DB3AA001723AD /* CGPoint+Utils.swift */,
 				A1DF90F12035992A00841A11 /* CGAffineTransform+Utils.swift */,
@@ -805,6 +808,7 @@
 				A1D4BD15202C6CC000FCDDEC /* Array+Utils.swift in Sources */,
 				C3E2EB8E20B8970800A42E58 /* UIImage+Utils.swift in Sources */,
 				A165F67E2044741B002D5ED6 /* ShutterButton.swift in Sources */,
+				64D4F6D422298DBC00B07103 /* Bundle+Utils.swift in Sources */,
 				B940E3AD21A829EE003B3C0B /* CaptureSession+Orientation.swift in Sources */,
 				B992E831210C36A400C33A21 /* VisionRectangleDetector.swift in Sources */,
 				B940E3D821AE0B42003B3C0B /* CaptureDevice.swift in Sources */,
@@ -1022,7 +1026,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 74N8K5J2N7;
+				DEVELOPMENT_TEAM = B629US47XJ;
 				INFOPLIST_FILE = WeScanSampleProject/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1039,7 +1043,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 74N8K5J2N7;
+				DEVELOPMENT_TEAM = B629US47XJ;
 				INFOPLIST_FILE = WeScanSampleProject/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1058,7 +1062,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 74N8K5J2N7;
+				DEVELOPMENT_TEAM = B629US47XJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1085,7 +1089,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 74N8K5J2N7;
+				DEVELOPMENT_TEAM = B629US47XJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/WeScan/Edit/EditScanViewController.swift
+++ b/WeScan/Edit/EditScanViewController.swift
@@ -31,7 +31,7 @@ final class EditScanViewController: UIViewController {
     }()
     
     lazy private var nextButton: UIBarButtonItem = {
-        let title = NSLocalizedString("wescan.edit.button.next", tableName: nil, bundle: Bundle(for: EditScanViewController.self), value: "Next", comment: "A generic next button")
+        let title = NSLocalizedString("wescan.edit.button.next", tableName: "Localizable", bundle: Bundle(for: EditScanViewController.self), value: "Next", comment: "A generic next button")
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(pushReviewController))
         button.tintColor = navigationController?.navigationBar.tintColor
         return button
@@ -65,7 +65,7 @@ final class EditScanViewController: UIViewController {
         
         setupViews()
         setupConstraints()
-        title = NSLocalizedString("wescan.edit.title", tableName: nil, bundle: Bundle(for: EditScanViewController.self), value: "Edit Scan", comment: "The title of the EditScanViewController")
+        title = NSLocalizedString("wescan.edit.title", tableName: "Localizable", bundle: Bundle(for: EditScanViewController.self), value: "Edit Scan", comment: "The title of the EditScanViewController")
         navigationItem.rightBarButtonItem = nextButton
         
         zoomGestureController = ZoomGestureController(image: image, quadView: quadView)

--- a/WeScan/Edit/EditScanViewController.swift
+++ b/WeScan/Edit/EditScanViewController.swift
@@ -31,7 +31,7 @@ final class EditScanViewController: UIViewController {
     }()
     
     lazy private var nextButton: UIBarButtonItem = {
-        let title = NSLocalizedString("wescan.edit.button.next", tableName: "Localizable", bundle: Bundle(for: EditScanViewController.self), value: "Next", comment: "A generic next button")
+        let title = Bundle.localizedString(aClass: EditScanViewController.self, key: "wescan.edit.button.next", value: "Next")
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(pushReviewController))
         button.tintColor = navigationController?.navigationBar.tintColor
         return button
@@ -65,7 +65,7 @@ final class EditScanViewController: UIViewController {
         
         setupViews()
         setupConstraints()
-        title = NSLocalizedString("wescan.edit.title", tableName: "Localizable", bundle: Bundle(for: EditScanViewController.self), value: "Edit Scan", comment: "The title of the EditScanViewController")
+        title = Bundle.localizedString(aClass: EditScanViewController.self, key: "wescan.edit.title", value: "Edit Scan")
         navigationItem.rightBarButtonItem = nextButton
         
         zoomGestureController = ZoomGestureController(image: image, quadView: quadView)

--- a/WeScan/Extensions/Bundle+Utils.swift
+++ b/WeScan/Extensions/Bundle+Utils.swift
@@ -1,0 +1,20 @@
+//
+//  Bundle+Utils.swift
+//  WeScan
+//
+//  Created by Daniele Galiotto on 01/03/2019.
+//  Copyright © 2019 WeTransfer. All rights reserved.
+//
+
+import UIKit
+
+extension Bundle {
+
+    class func localizedString(aClass: AnyClass, key: String, value: String?) -> String? {
+       guard let bundle = Bundle(for: aClass).path(forResource: "WeScan", ofType: "bundle"), let finalBundle = Bundle(path: bundle) else {
+            return Bundle.main.localizedString(forKey: key, value: value, table: nil)
+        }
+    
+        return finalBundle.localizedString(forKey: key, value: value, table: nil)
+    }
+}

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -68,7 +68,7 @@ final class ReviewViewController: UIViewController {
         setupToolbar()
         setupConstraints()
         
-        title = NSLocalizedString("wescan.review.title", tableName: nil, bundle: Bundle(for: ReviewViewController.self), value: "Review", comment: "The review title of the ReviewController")
+        title = NSLocalizedString("wescan.review.title", tableName: "Localizable", bundle: Bundle(for: ReviewViewController.self), value: "Review", comment: "The review title of the ReviewController")
         navigationItem.rightBarButtonItem = doneButton
     }
     

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -9,11 +9,13 @@
 import UIKit
 
 /// The `ReviewViewController` offers an interface to review the image after it has been cropped and deskwed according to the passed in quadrilateral.
-final class ReviewViewController: UIViewController {
+open class ReviewViewController: UIViewController {
     
     private var rotationAngle = Measurement<UnitAngle>(value: 0, unit: .degrees)
-    private var enhancedImageIsAvailable = false
-    private var isCurrentlyDisplayingEnhancedImage = false
+    open var enhancedImageIsAvailable = false
+    open var isCurrentlyDisplayingEnhancedImage = false
+    open var enhanceButtonTintColorOn: UIColor = .white
+    open var enhanceButtonTintColorOff: UIColor = UIColor(red: 64 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1.0)
     
     lazy var imageView: UIImageView = {
         let imageView = UIImageView()
@@ -55,11 +57,11 @@ final class ReviewViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         enhancedImageIsAvailable = results.enhancedImage != nil
@@ -67,12 +69,17 @@ final class ReviewViewController: UIViewController {
         setupViews()
         setupToolbar()
         setupConstraints()
+    
+        if enhancedImageIsAvailable {
+            isCurrentlyDisplayingEnhancedImage.toggle() //to set right value when the below toggleEnhancedImage is trigger
+            toggleEnhancedImage()
+        }
         
         title = NSLocalizedString("wescan.review.title", tableName: "Localizable", bundle: Bundle(for: ReviewViewController.self), value: "Review", comment: "The review title of the ReviewController")
         navigationItem.rightBarButtonItem = doneButton
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         // We only show the toolbar (with the enhance button) if the enhanced image is available.
@@ -81,7 +88,7 @@ final class ReviewViewController: UIViewController {
         }
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setToolbarHidden(true, animated: true)
     }
@@ -126,17 +133,17 @@ final class ReviewViewController: UIViewController {
     @objc private func toggleEnhancedImage() {
         guard enhancedImageIsAvailable else { return }
         
+        isCurrentlyDisplayingEnhancedImage.toggle()
+        
         reloadImage()
         
         if isCurrentlyDisplayingEnhancedImage {
-            enhanceButton.tintColor = .white
+            enhanceButton.tintColor = enhanceButtonTintColorOn
         } else {
-            enhanceButton.tintColor = UIColor(red: 64 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1.0)
+            enhanceButton.tintColor = enhanceButtonTintColorOff
         }
-        
-        isCurrentlyDisplayingEnhancedImage.toggle()
     }
-    
+
     @objc func rotateImage() {
         rotationAngle.value += 90
         

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -75,7 +75,7 @@ open class ReviewViewController: UIViewController {
             toggleEnhancedImage()
         }
         
-        title = NSLocalizedString("wescan.review.title", tableName: "Localizable", bundle: Bundle(for: ReviewViewController.self), value: "Review", comment: "The review title of the ReviewController")
+        title = Bundle.localizedString(aClass: EditScanViewController.self, key: "wescan.review.title", value: "Review")
         navigationItem.rightBarButtonItem = doneButton
     }
     

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -29,14 +29,14 @@ open class ReviewViewController: UIViewController {
     }()
     
     lazy private var enhanceButton: UIBarButtonItem = {
-        let image = UIImage(named: "enhance", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(named: "enhance", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "enhance")
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(toggleEnhancedImage))
         button.tintColor = .white
         return button
     }()
     
     lazy private var rotateButton: UIBarButtonItem = {
-        let image = UIImage(named: "rotate", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(named: "rotate", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "rotate")
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(rotateImage))
         button.tintColor = .white
         return button

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -39,14 +39,14 @@ final class ScannerViewController: UIViewController {
     
     lazy private var cancelButton: UIButton = {
         let button = UIButton()
-        button.setTitle(NSLocalizedString("wescan.scanning.cancel", tableName: nil, bundle: Bundle(for: ScannerViewController.self), value: "Cancel", comment: "The cancel button"), for: .normal)
+        button.setTitle(NSLocalizedString("wescan.scanning.cancel", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Cancel", comment: "The cancel button"), for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(cancelImageScannerController), for: .touchUpInside)
         return button
     }()
     
     lazy private var autoScanButton: UIBarButtonItem = {
-        let title = NSLocalizedString("wescan.scanning.auto", tableName: nil, bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
+        let title = NSLocalizedString("wescan.scanning.auto", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(toggleAutoScan))
         button.tintColor = .white
         
@@ -248,10 +248,10 @@ final class ScannerViewController: UIViewController {
     @objc private func toggleAutoScan() {
         if CaptureSession.current.isAutoScanEnabled {
             CaptureSession.current.isAutoScanEnabled = false
-            autoScanButton.title = NSLocalizedString("wescan.scanning.manual", tableName: nil, bundle: Bundle(for: ScannerViewController.self), value: "Manual", comment: "The manual button state")
+            autoScanButton.title = NSLocalizedString("wescan.scanning.manual", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Manual", comment: "The manual button state")
         } else {
             CaptureSession.current.isAutoScanEnabled = true
-            autoScanButton.title = NSLocalizedString("wescan.scanning.auto", tableName: nil, bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
+            autoScanButton.title = NSLocalizedString("wescan.scanning.auto", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
         }
     }
     

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -43,14 +43,14 @@ open class ScannerViewController: UIViewController {
     
     lazy private var cancelButton: UIButton = {
         let button = UIButton()
-        button.setTitle(NSLocalizedString("wescan.scanning.cancel", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Cancel", comment: "The cancel button"), for: .normal)
+        button.setTitle(Bundle.localizedString(aClass: ScannerViewController.self, key: "wescan.scanning.cancel", value: "Cancel"), for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(cancelImageScannerController), for: .touchUpInside)
         return button
     }()
     
     lazy private var autoScanButton: UIBarButtonItem = {
-        let title = NSLocalizedString("wescan.scanning.auto", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
+        let title = Bundle.localizedString(aClass: ScannerViewController.self, key: "wescan.scanning.auto", value: "Auto")
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(toggleAutoScan))
         button.tintColor = .white
         return button
@@ -254,10 +254,10 @@ open class ScannerViewController: UIViewController {
     @objc private func toggleAutoScan() {
         if CaptureSession.current.isAutoScanEnabled {
             CaptureSession.current.isAutoScanEnabled = false
-            autoScanButton.title = NSLocalizedString("wescan.scanning.manual", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Manual", comment: "The manual button state")
+            autoScanButton.title = Bundle.localizedString(aClass: ScannerViewController.self, key: "wescan.scanning.manual", value: "Manual")
         } else {
             CaptureSession.current.isAutoScanEnabled = true
-            autoScanButton.title = NSLocalizedString("wescan.scanning.auto", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
+            autoScanButton.title = Bundle.localizedString(aClass: ScannerViewController.self, key: "wescan.scanning.auto", value: "Auto")
         }
     }
     

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -57,7 +57,7 @@ open class ScannerViewController: UIViewController {
     }()
     
     lazy private var flashButton: UIBarButtonItem = {
-        let image = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "flash")
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(toggleFlash))
         button.tintColor = .white
         return button
@@ -152,7 +152,7 @@ open class ScannerViewController: UIViewController {
         navigationItem.setRightBarButton(autoScanButton, animated: false)
         
         if UIImagePickerController.isFlashAvailable(for: .rear) == false {
-            let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+            let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "flashUnavailable")
             flashButton.image = flashOffImage
             flashButton.tintColor = .lightGray
         }
@@ -264,8 +264,8 @@ open class ScannerViewController: UIViewController {
     @objc private func toggleFlash() {
         let state = CaptureSession.current.toggleFlash()
         
-        let flashImage = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
-        let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let flashImage = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "flash")
+        let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil) ?? UIImage(named: "flashUnavailable")
         
         switch state {
         case .on:

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -10,7 +10,11 @@ import UIKit
 import AVFoundation
 
 /// The `ScannerViewController` offers an interface to give feedback to the user regarding quadrilaterals that are detected. It also gives the user the opportunity to capture an image with a detected rectangle.
-final class ScannerViewController: UIViewController {
+open class ScannerViewController: UIViewController {
+    
+    open var flashButtonTintColorOn: UIColor = .yellow
+    open var flashButtonTintColorOff: UIColor = .white
+    open var flashButtonTintColorOther: UIColor = .lightGray
     
     private var captureSessionManager: CaptureSessionManager?
     private let videoPreviewLayer = AVCaptureVideoPreviewLayer()
@@ -25,7 +29,7 @@ final class ScannerViewController: UIViewController {
     private let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     
     /// Whether flash is enabled
-    private var flashEnabled = false
+    open var flashEnabled = false
     
     /// The original bar style that was set by the host app
     private var originalBarStyle: UIBarStyle?
@@ -49,7 +53,6 @@ final class ScannerViewController: UIViewController {
         let title = NSLocalizedString("wescan.scanning.auto", tableName: "Localizable", bundle: Bundle(for: ScannerViewController.self), value: "Auto", comment: "The auto button state")
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(toggleAutoScan))
         button.tintColor = .white
-        
         return button
     }()
     
@@ -57,7 +60,6 @@ final class ScannerViewController: UIViewController {
         let image = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(toggleFlash))
         button.tintColor = .white
-        
         return button
     }()
     
@@ -70,7 +72,7 @@ final class ScannerViewController: UIViewController {
 
     // MARK: - Life Cycle
 
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         
         title = nil
@@ -78,6 +80,10 @@ final class ScannerViewController: UIViewController {
         setupViews()
         setupNavigationBar()
         setupConstraints()
+        
+        CaptureSession.current.isAutoScanEnabled.toggle() //to set right value when the below toggleAutoScan is trigger
+        toggleAutoScan()
+        toggleFlash()
         
         captureSessionManager = CaptureSessionManager(videoPreviewLayer: videoPreviewLayer)
         captureSessionManager?.delegate = self
@@ -87,7 +93,7 @@ final class ScannerViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNeedsStatusBarAppearanceUpdate()
         
@@ -104,7 +110,7 @@ final class ScannerViewController: UIViewController {
         navigationController?.navigationBar.barStyle = .blackTranslucent
     }
     
-    override func viewDidLayoutSubviews() {
+    override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
         videoPreviewLayer.frame = view.layer.bounds
@@ -115,7 +121,7 @@ final class ScannerViewController: UIViewController {
         visualEffectView.frame = visualEffectRect ?? CGRect.zero
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         UIApplication.shared.isIdleTimerDisabled = false
         
@@ -148,7 +154,7 @@ final class ScannerViewController: UIViewController {
         if UIImagePickerController.isFlashAvailable(for: .rear) == false {
             let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
             flashButton.image = flashOffImage
-            flashButton.tintColor = UIColor.lightGray
+            flashButton.tintColor = .lightGray
         }
     }
     
@@ -215,7 +221,7 @@ final class ScannerViewController: UIViewController {
         CaptureSession.current.removeFocusRectangleIfNeeded(focusRectangle, animated: true)
     }
     
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         
         guard  let touch = touches.first else { return }
@@ -265,15 +271,15 @@ final class ScannerViewController: UIViewController {
         case .on:
             flashEnabled = true
             flashButton.image = flashImage
-            flashButton.tintColor = .yellow
+            flashButton.tintColor = flashButtonTintColorOn
         case .off:
             flashEnabled = false
             flashButton.image = flashImage
-            flashButton.tintColor = .white
+            flashButton.tintColor = flashButtonTintColorOff
         case .unknown, .unavailable:
             flashEnabled = false
             flashButton.image = flashOffImage
-            flashButton.tintColor = UIColor.lightGray
+            flashButton.tintColor = flashButtonTintColorOther
         }
     }
     


### PR DESCRIPTION
Fixed Localization when used like pods or framework.

Fixed ScannerViewController auto/manual state
Fixed ReviewViewController enhanced state
ScannerViewController is now open (so you can inherits from it when you works in an other module)
ReviewViewController is now open (so you can inherits from it it when you works in an other module)

New in ScannerViewController:
open var flashButtonTintColorOn: UIColor = .yellow
open var flashButtonTintColorOff: UIColor = .white
open var flashButtonTintColorOther: UIColor = .lightGray

New ReviewViewController:
open var enhancedImageIsAvailable = false
open var isCurrentlyDisplayingEnhancedImage = false //if true, starts immediatelly with enhanced image
open var enhanceButtonTintColorOn: UIColor = .white
open var enhanceButtonTintColorOff: UIColor = UIColor(red: 64 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1.0)