### PR TITLE
switch to CIPhotoEffectMono filter for grey scaling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,16 @@
+## Changelog
+
+### Next
+
+### 1.1.0
+
+- Updated to Swift 5.0
+- Added German translation
+- Several small improvements
+
+### 1.0 (2019-01-08)
+
+- Add support for French, Italian, Portuguese, Chinese (Simplified) and Chinese (Traditional)
+- Add support to enhance the scanned image using AdaptiveThresholding 
+- Updated to Swift 4.2
+- Add auto rotate, auto scan, and Vision support

--- a/WeScan.podspec
+++ b/WeScan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'WeScan'
-  spec.version          = '0.9.2'
+  spec.version          = '1.1.0'
   spec.summary          = 'Document Scanning Made Easy for iOS'
   spec.description      = 'WeScan makes it easy to add scanning functionalities to your iOS app! It\'s modelled after UIImagePickerController, which makes it a breeze to use.'
 
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/WeTransfer/WeScan.git', :tag => "v#{spec.version}" }
   spec.social_media_url = 'https://twitter.com/WeTransfer'
 
-  spec.swift_version = '4.2'
+  spec.swift_version = '5.0'
   spec.ios.deployment_target = '10.0'
   spec.source_files = 'WeScan/**/*.{h,m,swift}'
   spec.resources = 'WeScan/**/*.{strings,png}'

--- a/WeScan.xcodeproj/xcshareddata/xcschemes/WeScan.xcscheme
+++ b/WeScan.xcodeproj/xcshareddata/xcschemes/WeScan.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WeScan/Edit/EditScanViewController.swift
+++ b/WeScan/Edit/EditScanViewController.swift
@@ -142,7 +142,7 @@ final class EditScanViewController: UIViewController {
             "inputBottomRight": CIVector(cgPoint: cartesianScaledQuad.topRight)
             ])
         
-        let enhancedImage = filteredImage.applyingAdaptiveThreshold()?.withFixedOrientation()
+        let enhancedImage = filteredImage.applyingPhotoEffectMono()?.withFixedOrientation()
         
         var uiImage: UIImage!
         

--- a/WeScan/Edit/EditScanViewController.swift
+++ b/WeScan/Edit/EditScanViewController.swift
@@ -50,7 +50,7 @@ final class EditScanViewController: UIViewController {
     
     // MARK: - Life Cycle
     
-    init(image: UIImage, quad: Quadrilateral?, rotateImage: Bool = true) {
+    init(image: UIImage, quad: Quadrilateral?, rotateImage: Bool = true, useAdaptiveThreshold: Bool = true) {
         self.image = rotateImage ? image.applyingPortraitOrientation() : image
         self.quad = quad ?? EditScanViewController.defaultQuad(forImage: image)
         super.init(nibName: nil, bundle: nil)
@@ -141,8 +141,13 @@ final class EditScanViewController: UIViewController {
             "inputBottomLeft": CIVector(cgPoint: cartesianScaledQuad.topLeft),
             "inputBottomRight": CIVector(cgPoint: cartesianScaledQuad.topRight)
             ])
-        
-        let enhancedImage = filteredImage.applyingPhotoEffectMono()?.withFixedOrientation()
+
+        let enhancedImage: CIImage
+        if useAdaptiveThreshold {
+            enhancedImage = filteredImage.applyingAdaptiveThreshold()?.withFixedOrientation()
+        } else {
+            enhancedImage = filteredImage.applyingPhotoEffectMono()?.withFixedOrientation()
+        }
         
         var uiImage: UIImage!
         

--- a/WeScan/Extensions/CIImage+Utils.swift
+++ b/WeScan/Extensions/CIImage+Utils.swift
@@ -10,6 +10,34 @@ import CoreImage
 import Foundation
 
 extension CIImage {
+
+    /// Applies an AdaptiveThresholding filter to the image, which enhances the image and makes it completely gray scale
+    func applyingAdaptiveThreshold() -> UIImage? {
+        guard let colorKernel = CIColorKernel(source:
+            """
+            kernel vec4 color(__sample pixel, float inputEdgeO, float inputEdge1)
+            {
+                float luma = dot(pixel.rgb, vec3(0.2126, 0.7152, 0.0722));
+                float threshold = smoothstep(inputEdgeO, inputEdge1, luma);
+                return vec4(threshold, threshold, threshold, 1.0);
+            }
+            """
+            ) else { return nil }
+
+        let firstInputEdge = 0.25
+        let secondInputEdge = 0.75
+
+        let arguments: [Any] = [self, firstInputEdge, secondInputEdge]
+
+        guard let enhancedCIImage = colorKernel.apply(extent: self.extent, arguments: arguments) else { return nil }
+
+        if let cgImage = CIContext(options: nil).createCGImage(enhancedCIImage, from: enhancedCIImage.extent) {
+            return UIImage(cgImage: cgImage)
+        } else {
+            return UIImage(ciImage: enhancedCIImage, scale: 1.0, orientation: .up)
+        }
+    }
+
     /// Applies an PhotoEffectMono filter to the image, which enhances the image and makes it completely gray scale
     func applyingPhotoEffectMono() -> UIImage? {
         let context = CIContext(options: nil)

--- a/WeScan/Extensions/CIImage+Utils.swift
+++ b/WeScan/Extensions/CIImage+Utils.swift
@@ -10,30 +10,15 @@ import CoreImage
 import Foundation
 
 extension CIImage {
-    /// Applies an AdaptiveThresholding filter to the image, which enhances the image and makes it completely gray scale
-    func applyingAdaptiveThreshold() -> UIImage? {
-        guard let colorKernel = CIColorKernel(source:
-            """
-            kernel vec4 color(__sample pixel, float inputEdgeO, float inputEdge1)
-            {
-                float luma = dot(pixel.rgb, vec3(0.2126, 0.7152, 0.0722));
-                float threshold = smoothstep(inputEdgeO, inputEdge1, luma);
-                return vec4(threshold, threshold, threshold, 1.0);
-            }
-            """
-            ) else { return nil }
-        
-        let firstInputEdge = 0.25
-        let secondInputEdge = 0.75
-        
-        let arguments: [Any] = [self, firstInputEdge, secondInputEdge]
-
-        guard let enhancedCIImage = colorKernel.apply(extent: self.extent, arguments: arguments) else { return nil }
-
-        if let cgImage = CIContext(options: nil).createCGImage(enhancedCIImage, from: enhancedCIImage.extent) {
+    /// Applies an PhotoEffectMono filter to the image, which enhances the image and makes it completely gray scale
+    func applyingPhotoEffectMono() -> UIImage? {
+        let context = CIContext(options: nil)
+        guard let currentFilter = CIFilter(name: "CIPhotoEffectMono") else { return nil }
+        currentFilter.setValue(self, forKey: kCIInputImageKey)
+        if let output = currentFilter.outputImage,
+            let cgImage = context.createCGImage(output, from: output.extent) {
             return UIImage(cgImage: cgImage)
-        } else {
-            return UIImage(ciImage: enhancedCIImage, scale: 1.0, orientation: .up)
         }
+        return nil
     }
 }

--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -56,7 +56,7 @@ public final class ImageScannerController: UINavigationController {
         return view
     }()
     
-    public required init(image: UIImage? = nil, delegate: ImageScannerControllerDelegate? = nil) {
+    public required init(image: UIImage? = nil, delegate: ImageScannerControllerDelegate? = nil, useAdaptiveThreshold: Bool = true) {
         super.init(rootViewController: ScannerViewController())
         
         self.imageScannerDelegate = delegate
@@ -75,7 +75,7 @@ public final class ImageScannerController: UINavigationController {
             // *** Vision *requires* a completion block to detect rectangles, but it's instant.
             // *** When using Vision, we'll present the normal edit view controller first, then present the updated edit view controller later.
             defer {
-                let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
+                let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false, useAdaptiveThreshold: useAdaptiveThreshold)
                 setViewControllers([editViewController], animated: false)
             }
             
@@ -87,7 +87,7 @@ public final class ImageScannerController: UINavigationController {
                     detectedQuad = quad
                     detectedQuad?.reorganize()
 
-                    let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
+                    let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false, useAdaptiveThreshold: useAdaptiveThreshold)
                     self.setViewControllers([editViewController], animated: true)
                 }
             } else {

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -299,10 +299,10 @@ extension ScannerViewController: RectangleDetectionDelegateProtocol {
         shutterButton.isUserInteractionEnabled = false
     }
     
-    func captureSessionManager(_ captureSessionManager: CaptureSessionManager, didCapturePicture picture: UIImage, withQuad quad: Quadrilateral?) {
+    func captureSessionManager(_ captureSessionManager: CaptureSessionManager, didCapturePicture picture: UIImage, withQuad quad: Quadrilateral?, useAdaptiveThreshold: Bool = true) {
         activityIndicator.stopAnimating()
         
-        let editVC = EditScanViewController(image: picture, quad: quad)
+        let editVC = EditScanViewController(image: picture, quad: quad, rotateImage: true, useAdaptiveThreshold: useAdaptiveThreshold)
         navigationController?.pushViewController(editVC, animated: false)
         
         shutterButton.isUserInteractionEnabled = true

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -84,7 +84,7 @@ final class ScannerViewController: UIViewController {
         
         originalBarStyle = navigationController?.navigationBar.barStyle
         
-        NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: Notification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Hi,
first of all: thank you very very much for open sourcing this project! I am working on an iOS version of [PDF Archiver](https://pdf-archiver.io) and want to use WeScan for scanning the documents, which will be saved as PDFs (via [SwiftyTesseract](https://github.com/SwiftyTesseract/SwiftyTesseract)).

I started scanning some documents and got some bad results for the "enhanced picture" in the review screen:

<img src="https://user-images.githubusercontent.com/6580313/56078149-fbcdb580-5de4-11e9-92e1-5419b5cf3677.png" height="400" /><img src="https://user-images.githubusercontent.com/6580313/56078151-fbcdb580-5de4-11e9-8a06-317e519f941d.png" height="400" /><img src="https://user-images.githubusercontent.com/6580313/56078154-fc664c00-5de4-11e9-9c22-61de76a18046.png" height="400" />

I changed the "adaptive threshold" filter to  "[CIPhotoEffectMono](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIPhotoEffectMono)" (in https://github.com/PDF-Archiver/WeScan/commit/4b183522cc5d5d229cc545a8bf3bb06d98cc3839) which improved the results:

<img src="https://user-images.githubusercontent.com/6580313/56078150-fbcdb580-5de4-11e9-84fb-cc0ae918a998.png" height="400" /><img src="https://user-images.githubusercontent.com/6580313/56078152-fbcdb580-5de4-11e9-9291-39a55dfb1554.png" height="400" /><img src="https://user-images.githubusercontent.com/6580313/56078155-fc664c00-5de4-11e9-863e-fb1de62a813f.png" height="400" />

Since this is no large testbase I am not sure, if this decreases the image quality in some cases. Some more information about the images:
- They come from 2 different "scan sessions".
- The images are screenshots of the "ReviewViewController". 

What do you think about it?