### PR TITLE
Camera Rotation

### DIFF
--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -117,10 +117,6 @@ public final class ImageScannerController: UINavigationController {
         NSLayoutConstraint.activate(blackFlashViewConstraints)
     }
     
-    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
-    }
-    
     internal func flashToBlack() {
         view.bringSubviewToFront(blackFlashView)
         blackFlashView.isHidden = false


### PR DESCRIPTION
In 7c79c6f0c05f010a1b1af8cd4c86b330dc497b84 I have already fixed the missing "change of orientation" in the ScanViewController. However, the captured image is always displayed in portrait mode in the EditViewController. This is due to a wrong UIImage.imageOrientation.

I'm not sure where to set the imageOrientation of the newly captured image. Or if it should be changed at all, since this could lead the user to change to portrait mode in the EditViewController.
Does anyone have a hint for me?

fixes #76