### PR TITLE
iOS 13 dark mode compatibility

### DIFF
--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -61,7 +61,13 @@ public final class ImageScannerController: UINavigationController {
         
         self.imageScannerDelegate = delegate
         
-        navigationBar.tintColor = .black
+        if #available(iOS 13.0, *) {
+            // Use semantic colors for Dark Mode compatibility on iOS 13+
+            navigationBar.tintColor = .label
+        } else {
+            navigationBar.tintColor = .black
+        }
+
         navigationBar.isTranslucent = false
         self.view.addSubview(blackFlashView)
         setupConstraints()


### PR DESCRIPTION
A very small tweak to resolve nav bar buttons becoming illegible when dark mode is enabled on iOS 13. Resolves #180.

**Before:**

![Screen Shot 2019-09-18 at 8 51 42 pm](https://user-images.githubusercontent.com/4055224/65142480-2982ee80-da56-11e9-902c-505cdb9155ef.png)
![Screen Shot 2019-09-18 at 8 51 51 pm](https://user-images.githubusercontent.com/4055224/65142541-47505380-da56-11e9-9742-30aa6b2454a2.png)

**After:**
![Screen Shot 2019-09-18 at 8 53 53 pm](https://user-images.githubusercontent.com/4055224/65142622-76ff5b80-da56-11e9-8fd9-6b3e58862af9.png)
![Screen Shot 2019-09-18 at 8 54 00 pm](https://user-images.githubusercontent.com/4055224/65142623-7961b580-da56-11e9-83d0-aa78994505d1.png)

