### PR TITLE
Added delegate argument to class `CaptureSessionManager` init.

### DIFF
--- a/WeScan.xcodeproj/project.pbxproj
+++ b/WeScan.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		C31DD8A220C087D80072D439 /* ZoomGestureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomGestureController.swift; sourceTree = "<group>"; };
 		C3789C9A20CC69AD001B423F /* QuadrilateralViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuadrilateralViewTests.swift; sourceTree = "<group>"; };
 		C3E2EB8D20B8970800A42E58 /* UIImage+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Utils.swift"; sourceTree = "<group>"; };
+		D40239502448ADD60027CCFF /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -674,6 +675,7 @@
 				es,
 				"es-419",
 				tr,
+				ru,
 			);
 			mainGroup = A1D4BCAE202C4F3800FCDDEC;
 			productRefGroup = A1D4BCB8202C4F3800FCDDEC /* Products */;
@@ -967,6 +969,7 @@
 				75629CE3241664D2008777A5 /* es */,
 				75629CE4241664E0008777A5 /* es-419 */,
 				731898DA243A753C00EA7356 /* tr */,
+				D40239502448ADD60027CCFF /* ru */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/WeScan/Scan/CaptureSessionManager.swift
+++ b/WeScan/Scan/CaptureSessionManager.swift
@@ -62,8 +62,13 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
     
     // MARK: Life Cycle
     
-    init?(videoPreviewLayer: AVCaptureVideoPreviewLayer) {
+    init?(videoPreviewLayer: AVCaptureVideoPreviewLayer, delegate: RectangleDetectionDelegateProtocol? = nil) {
         self.videoPreviewLayer = videoPreviewLayer
+        
+        if delegate != nil {
+            self.delegate = delegate
+        }
+        
         super.init()
         
         guard let device = AVCaptureDevice.default(for: AVMediaType.video) else {

--- a/WeScan/Scan/CaptureSessionManager.swift
+++ b/WeScan/Scan/CaptureSessionManager.swift
@@ -47,7 +47,7 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
     private let videoPreviewLayer: AVCaptureVideoPreviewLayer
     private let captureSession = AVCaptureSession()
     private let rectangleFunnel = RectangleFeaturesFunnel()
-    private weak var delegate: RectangleDetectionDelegateProtocol?
+    weak var delegate: RectangleDetectionDelegateProtocol?
     private var displayedRectangleResult: RectangleDetectorResult?
     private var photoOutput = AVCapturePhotoOutput()
     

--- a/WeScan/Scan/CaptureSessionManager.swift
+++ b/WeScan/Scan/CaptureSessionManager.swift
@@ -47,7 +47,7 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
     private let videoPreviewLayer: AVCaptureVideoPreviewLayer
     private let captureSession = AVCaptureSession()
     private let rectangleFunnel = RectangleFeaturesFunnel()
-    weak var delegate: RectangleDetectionDelegateProtocol?
+    private weak var delegate: RectangleDetectionDelegateProtocol?
     private var displayedRectangleResult: RectangleDetectorResult?
     private var photoOutput = AVCapturePhotoOutput()
     
@@ -62,18 +62,14 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
     
     // MARK: Life Cycle
     
-    init?(videoPreviewLayer: AVCaptureVideoPreviewLayer, delegate: RectangleDetectionDelegateProtocol? = nil) {
+    init?(videoPreviewLayer: AVCaptureVideoPreviewLayer, delegate: RectangleDetectionDelegateProtocol) {
         self.videoPreviewLayer = videoPreviewLayer
-        
-        if delegate != nil {
-            self.delegate = delegate
-        }
-        
+        self.delegate = delegate
         super.init()
         
         guard let device = AVCaptureDevice.default(for: AVMediaType.video) else {
             let error = ImageScannerControllerError.inputDevice
-            delegate?.captureSessionManager(self, didFailWithError: error)
+            delegate.captureSessionManager(self, didFailWithError: error)
             return nil
         }
         
@@ -95,7 +91,7 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
             captureSession.canAddOutput(photoOutput),
             captureSession.canAddOutput(videoOutput) else {
                 let error = ImageScannerControllerError.inputDevice
-                delegate?.captureSessionManager(self, didFailWithError: error)
+                delegate.captureSessionManager(self, didFailWithError: error)
                 return
         }
         
@@ -103,7 +99,7 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
             try device.lockForConfiguration()
         } catch {
             let error = ImageScannerControllerError.inputDevice
-            delegate?.captureSessionManager(self, didFailWithError: error)
+            delegate.captureSessionManager(self, didFailWithError: error)
             return
         }
         

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -76,8 +76,7 @@ final class ScannerViewController: UIViewController {
         setupNavigationBar()
         setupConstraints()
         
-        captureSessionManager = CaptureSessionManager(videoPreviewLayer: videoPreviewLayer)
-        captureSessionManager?.delegate = self
+        captureSessionManager = CaptureSessionManager(videoPreviewLayer: videoPreviewLayer, delegate: self)
         
         originalBarStyle = navigationController?.navigationBar.barStyle
         

--- a/WeScan/Scan/ShutterButton.swift
+++ b/WeScan/Scan/ShutterButton.swift
@@ -27,7 +27,7 @@ final class ShutterButton: UIControl {
         }
     }
     
-    // MARL: Life Cycle
+    // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/WeScan/ru.lproj/Localizable.strings
+++ b/WeScan/ru.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+/*
+    localizable.strings
+    WeScanSampleProject
+
+    Created by Dmitriy Toropkin on 4/16/20.
+    Copyright © 2020 Dmitriy Toropkin. All rights reserved.
+*/
+
+/* The "Next" button on the right side of the navigation bar on the Edit screen. */
+"wescan.edit.button.next" = "Продолжить";
+
+/* The title on the navigation bar of the Edit screen. */
+"wescan.edit.title" = "Редактирование";
+
+/* The title on the navigation bar of the Review screen. */
+"wescan.review.title" = "Предпросмотр";
+
+/* The button titles on the Scanning screen. */
+"wescan.scanning.cancel" = "Отмена";
+"wescan.scanning.auto" = "Авто";
+"wescan.scanning.manual" = "Ручное";


### PR DESCRIPTION
The `CaptureSessionManager` delegate can only be assigned after successful initialization, making the calls to the delegate inside the init block redundant.

Fixed by including the delegate as an argument to init.