### PR TITLE
Fix error description typo

### DIFF
--- a/WeScan/Common/Error.swift
+++ b/WeScan/Common/Error.swift
@@ -29,7 +29,7 @@ extension ImageScannerControllerError: LocalizedError {
         case .inputDevice:
             return "Could not setup input device."
         case .capture:
-            return "Could not capture pitcure."
+            return "Could not capture picture."
         case .ciImageCreation:
             return "Internal Error - Could not create CIImage"
         }


### PR DESCRIPTION
Fix `ImageScannerControllerError.capture` error description typo.