### PR TITLE
SF Symbols

### DIFF
--- a/WeScan.xcodeproj/project.pbxproj
+++ b/WeScan.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		74F7D03A211ACC4B0046AF7E /* UIImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F7D039211ACC4B0046AF7E /* UIImageTests.swift */; };
 		74F7D03C211ACC6B0046AF7E /* CGAffineTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F7D03B211ACC6B0046AF7E /* CGAffineTransformTests.swift */; };
 		74F7D03E211ACC890046AF7E /* AVCaptureVideoOrientationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F7D03D211ACC890046AF7E /* AVCaptureVideoOrientationTests.swift */; };
+		8A1BB199249C9B45000278F2 /* UIImage+SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1BB198249C9B45000278F2 /* UIImage+SFSymbol.swift */; };
 		A11C5B9C2046A20C005075FE /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5B9B2046A20C005075FE /* Error.swift */; };
 		A11C5CD920495EA1005075FE /* RectangleFeaturesFunnelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5CD820495EA1005075FE /* RectangleFeaturesFunnelTests.swift */; };
 		A11C5CDB20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C5CDA20495EC9005075FE /* AVCaptureVideoOrientation+Utils.swift */; };
@@ -200,6 +201,7 @@
 		75629CE3241664D2008777A5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		75629CE4241664E0008777A5 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		82A414A022B9391B00DF5831 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		8A1BB198249C9B45000278F2 /* UIImage+SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SFSymbol.swift"; sourceTree = "<group>"; };
 		9541C84122155DD3005FBCD3 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A11C5B9B2046A20C005075FE /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		A11C5CD820495EA1005075FE /* RectangleFeaturesFunnelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleFeaturesFunnelTests.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				B9274D39219B951000F9FCD1 /* CIImage+Utils.swift */,
 				C3E2EB8D20B8970800A42E58 /* UIImage+Utils.swift */,
 				A1DF90F52037187500841A11 /* UIImage+Orientation.swift */,
+				8A1BB198249C9B45000278F2 /* UIImage+SFSymbol.swift */,
 				362967772294C23700B9FC4A /* CGImagePropertyOrientation.swift */,
 			);
 			path = Extensions;
@@ -866,6 +869,7 @@
 				A1D4BD0C202C504F00FCDDEC /* ScannerViewController.swift in Sources */,
 				A11C5B9C2046A20C005075FE /* Error.swift in Sources */,
 				B940E3DE21AE2A79003B3C0B /* CaptureSession+Focus.swift in Sources */,
+				8A1BB199249C9B45000278F2 /* UIImage+SFSymbol.swift in Sources */,
 				B940E3DC21AE2A64003B3C0B /* CaptureSession+Flash.swift in Sources */,
 				A1D4BD15202C6CC000FCDDEC /* Array+Utils.swift in Sources */,
 				C3E2EB8E20B8970800A42E58 /* UIImage+Utils.swift in Sources */,

--- a/WeScan/Extensions/UIImage+SFSymbol.swift
+++ b/WeScan/Extensions/UIImage+SFSymbol.swift
@@ -1,0 +1,21 @@
+//
+//  UIImage+SFSymbol.swift
+//  WeScan
+//
+//  Created by André Schmidt on 19/06/2020.
+//  Copyright © 2020 WeTransfer. All rights reserved.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    /// Creates an image object containing a system symbol image appropriate for the specified traits if supported (iOS13 and above). Otherwise an image object using the named image asset that is compatible with the specified trait collection will be created.
+    convenience init?(systemName: String, named: String, in bundle: Bundle? = nil, compatibleWith traitCollection: UITraitCollection? = nil) {
+        if #available(iOS 13.0, *) {
+            self.init(systemName: systemName, compatibleWith: traitCollection)
+        } else {
+            self.init(named: named, in: bundle, compatibleWith: traitCollection)
+        }
+    }
+}

--- a/WeScan/Review/ReviewViewController.swift
+++ b/WeScan/Review/ReviewViewController.swift
@@ -27,14 +27,14 @@ final class ReviewViewController: UIViewController {
     }()
     
     private lazy var enhanceButton: UIBarButtonItem = {
-        let image = UIImage(named: "enhance", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(systemName: "wand.and.rays.inverse", named: "enhance", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(toggleEnhancedImage))
         button.tintColor = .white
         return button
     }()
     
     private lazy var rotateButton: UIBarButtonItem = {
-        let image = UIImage(named: "rotate", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(systemName: "rotate.right", named: "rotate", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(rotateImage))
         button.tintColor = .white
         return button

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -51,7 +51,7 @@ final class ScannerViewController: UIViewController {
     }()
     
     private lazy var flashButton: UIBarButtonItem = {
-        let image = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let image = UIImage(systemName: "bolt.fill", named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(toggleFlash))
         button.tintColor = .white
         
@@ -132,7 +132,7 @@ final class ScannerViewController: UIViewController {
         navigationItem.setRightBarButton(autoScanButton, animated: false)
         
         if UIImagePickerController.isFlashAvailable(for: .rear) == false {
-            let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+            let flashOffImage = UIImage(systemName: "bolt.slash.fill", named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
             flashButton.image = flashOffImage
             flashButton.tintColor = UIColor.lightGray
         }
@@ -244,8 +244,8 @@ final class ScannerViewController: UIViewController {
     @objc private func toggleFlash() {
         let state = CaptureSession.current.toggleFlash()
         
-        let flashImage = UIImage(named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
-        let flashOffImage = UIImage(named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let flashImage = UIImage(systemName: "bolt.fill", named: "flash", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
+        let flashOffImage = UIImage(systemName: "bolt.slash.fill", named: "flashUnavailable", in: Bundle(for: ScannerViewController.self), compatibleWith: nil)
         
         switch state {
         case .on:


### PR DESCRIPTION
Use [SF Symbols](https://developer.apple.com/documentation/uikit/uiimage/configuring_and_displaying_symbol_images_in_your_ui/) for iOS13 and above. This ensures hi quality rendering of icons if scaled (i.e. using accessibility features).

12f29ad ensures backward compatibility. 

Below is a comparison using enlarged font sizes. Holding down a button will enlarge it in a HUD.
Current (bitmap) | SF Symbol/Vector
-----|-----
![bitmap1](https://user-images.githubusercontent.com/1392414/85171207-d650fd00-b26e-11ea-9e15-e5f18d00ec37.png) | ![vector1](https://user-images.githubusercontent.com/1392414/85171226-e49f1900-b26e-11ea-9c8e-3e39b7baba77.png)
![bitmap2](https://user-images.githubusercontent.com/1392414/85171239-ec5ebd80-b26e-11ea-8566-901efaf31dac.png) | ![vector2](https://user-images.githubusercontent.com/1392414/85171246-f1237180-b26e-11ea-87d4-92bc70628052.png)

