### PR TITLE
Allow support for using an image after instantiation

### DIFF
--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -79,7 +79,7 @@ public final class ImageScannerController: UINavigationController {
             self.detect(image: image) { [weak self] detectedQuad in
                 guard let self = self else { return }
                 let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
-                self.setViewControllers([editViewController], animated: true)
+                self.setViewControllers([editViewController], animated: false)
             }
         }
     }

--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -76,7 +76,7 @@ public final class ImageScannerController: UINavigationController {
         
         // If an image was passed in by the host app (e.g. picked from the photo library), use it instead of the document scanner.
         if let image = image {
-            self.detect(image: image) { [weak self] detectedQuad in
+            detect(image: image) { [weak self] detectedQuad in
                 guard let self = self else { return }
                 let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
                 self.setViewControllers([editViewController], animated: false)
@@ -92,7 +92,7 @@ public final class ImageScannerController: UINavigationController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func detect(image: UIImage, completion: @escaping (Quadrilateral?) -> ()) {
+    private func detect(image: UIImage, completion: @escaping (Quadrilateral?) -> Void) {
         // Whether or not we detect a quad, present the edit view controller after attempting to detect a quad.
         // *** Vision *requires* a completion block to detect rectangles, but it's instant.
         // *** When using Vision, we'll present the normal edit view controller first, then present the updated edit view controller later.
@@ -115,9 +115,9 @@ public final class ImageScannerController: UINavigationController {
     }
     
     public func useImage(image: UIImage) {
-        guard self.topViewController is ScannerViewController else { return }
+        guard topViewController is ScannerViewController else { return }
         
-        self.detect(image: image) { [weak self] detectedQuad in
+        detect(image: image) { [weak self] detectedQuad in
             guard let self = self else { return }
             let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
             self.setViewControllers([editViewController], animated: true)
@@ -125,7 +125,7 @@ public final class ImageScannerController: UINavigationController {
     }
     
     public func resetScanner() {
-        self.setViewControllers([ScannerViewController()], animated: true)
+        setViewControllers([ScannerViewController()], animated: true)
     }
     
     private func setupConstraints() {

--- a/WeScan/ImageScannerController.swift
+++ b/WeScan/ImageScannerController.swift
@@ -76,29 +76,10 @@ public final class ImageScannerController: UINavigationController {
         
         // If an image was passed in by the host app (e.g. picked from the photo library), use it instead of the document scanner.
         if let image = image {
-            
-            var detectedQuad: Quadrilateral?
-            
-            // Whether or not we detect a quad, present the edit view controller after attempting to detect a quad.
-            // *** Vision *requires* a completion block to detect rectangles, but it's instant.
-            // *** When using Vision, we'll present the normal edit view controller first, then present the updated edit view controller later.
-           
-            guard let ciImage = CIImage(image: image) else { return }
-            let orientation = CGImagePropertyOrientation(image.imageOrientation)
-            let orientedImage = ciImage.oriented(forExifOrientation: Int32(orientation.rawValue))
-            if #available(iOS 11.0, *) {
-                
-                // Use the VisionRectangleDetector on iOS 11 to attempt to find a rectangle from the initial image.
-                VisionRectangleDetector.rectangle(forImage: ciImage, orientation: orientation) { (quad) in
-                    detectedQuad = quad?.toCartesian(withHeight: orientedImage.extent.height)
-                    let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
-                    self.setViewControllers([editViewController], animated: true)
-                }
-            } else {
-                // Use the CIRectangleDetector on iOS 10 to attempt to find a rectangle from the initial image.
-                detectedQuad = CIRectangleDetector.rectangle(forImage: ciImage)?.toCartesian(withHeight: orientedImage.extent.height)
+            self.detect(image: image) { [weak self] detectedQuad in
+                guard let self = self else { return }
                 let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
-                setViewControllers([editViewController], animated: false)
+                self.setViewControllers([editViewController], animated: true)
             }
         }
     }
@@ -109,6 +90,42 @@ public final class ImageScannerController: UINavigationController {
     
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func detect(image: UIImage, completion: @escaping (Quadrilateral?) -> ()) {
+        // Whether or not we detect a quad, present the edit view controller after attempting to detect a quad.
+        // *** Vision *requires* a completion block to detect rectangles, but it's instant.
+        // *** When using Vision, we'll present the normal edit view controller first, then present the updated edit view controller later.
+        
+        guard let ciImage = CIImage(image: image) else { return }
+        let orientation = CGImagePropertyOrientation(image.imageOrientation)
+        let orientedImage = ciImage.oriented(forExifOrientation: Int32(orientation.rawValue))
+        
+        if #available(iOS 11.0, *) {
+            // Use the VisionRectangleDetector on iOS 11 to attempt to find a rectangle from the initial image.
+            VisionRectangleDetector.rectangle(forImage: ciImage, orientation: orientation) { (quad) in
+                let detectedQuad = quad?.toCartesian(withHeight: orientedImage.extent.height)
+                completion(detectedQuad)
+            }
+        } else {
+            // Use the CIRectangleDetector on iOS 10 to attempt to find a rectangle from the initial image.
+            let detectedQuad = CIRectangleDetector.rectangle(forImage: ciImage)?.toCartesian(withHeight: orientedImage.extent.height)
+            completion(detectedQuad)
+        }
+    }
+    
+    public func useImage(image: UIImage) {
+        guard self.topViewController is ScannerViewController else { return }
+        
+        self.detect(image: image) { [weak self] detectedQuad in
+            guard let self = self else { return }
+            let editViewController = EditScanViewController(image: image, quad: detectedQuad, rotateImage: false)
+            self.setViewControllers([editViewController], animated: true)
+        }
+    }
+    
+    public func resetScanner() {
+        self.setViewControllers([ScannerViewController()], animated: true)
     }
     
     private func setupConstraints() {

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -67,7 +67,7 @@ public final class ScannerViewController: UIViewController {
 
     // MARK: - Life Cycle
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         
         title = nil
@@ -84,7 +84,7 @@ public final class ScannerViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: Notification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNeedsStatusBarAppearanceUpdate()
         
@@ -96,13 +96,13 @@ public final class ScannerViewController: UIViewController {
         navigationController?.navigationBar.barStyle = .blackTranslucent
     }
     
-    public override func viewDidLayoutSubviews() {
+    override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
         videoPreviewLayer.frame = view.layer.bounds
     }
     
-    public override func viewWillDisappear(_ animated: Bool) {
+    override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         UIApplication.shared.isIdleTimerDisabled = false
         
@@ -202,7 +202,7 @@ public final class ScannerViewController: UIViewController {
         CaptureSession.current.removeFocusRectangleIfNeeded(focusRectangle, animated: true)
     }
     
-    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         
         guard  let touch = touches.first else { return }

--- a/WeScan/Scan/ScannerViewController.swift
+++ b/WeScan/Scan/ScannerViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import AVFoundation
 
 /// The `ScannerViewController` offers an interface to give feedback to the user regarding quadrilaterals that are detected. It also gives the user the opportunity to capture an image with a detected rectangle.
-final class ScannerViewController: UIViewController {
+public final class ScannerViewController: UIViewController {
     
     private var captureSessionManager: CaptureSessionManager?
     private let videoPreviewLayer = AVCaptureVideoPreviewLayer()
@@ -67,10 +67,11 @@ final class ScannerViewController: UIViewController {
 
     // MARK: - Life Cycle
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         
         title = nil
+        view.backgroundColor = UIColor.black
         
         setupViews()
         setupNavigationBar()
@@ -83,7 +84,7 @@ final class ScannerViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: Notification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNeedsStatusBarAppearanceUpdate()
         
@@ -95,13 +96,13 @@ final class ScannerViewController: UIViewController {
         navigationController?.navigationBar.barStyle = .blackTranslucent
     }
     
-    override func viewDidLayoutSubviews() {
+    public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
         videoPreviewLayer.frame = view.layer.bounds
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         UIApplication.shared.isIdleTimerDisabled = false
         
@@ -201,7 +202,7 @@ final class ScannerViewController: UIViewController {
         CaptureSession.current.removeFocusRectangleIfNeeded(focusRectangle, animated: true)
     }
     
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         
         guard  let touch = touches.first else { return }


### PR DESCRIPTION
This change moves quad detection code into the method `detect(image:)` so it can be accessed post-instantiation. This is utilized by `useImage(image:)`, which will push an `EditScanViewController` even after the main VC is presented. For an example of how I've been using this in production, [see this video](https://imgur.com/a/kEY0ukJ).

I also made `ScannerViewController` public so client code can inspect the controller hierarchy for this specific controller.