### PR TITLE
Fix broken iOS 14 AV apple api

### DIFF
--- a/WeScan/Scan/CaptureSessionManager.swift
+++ b/WeScan/Scan/CaptureSessionManager.swift
@@ -80,12 +80,6 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
         
         captureSession.beginConfiguration()
         
-        let photoPreset = AVCaptureSession.Preset.photo
-        
-        if captureSession.canSetSessionPreset(photoPreset) {
-            captureSession.sessionPreset = photoPreset
-        }
-        
         photoOutput.isHighResolutionCaptureEnabled = true
         
         let videoOutput = AVCaptureVideoDataOutput()
@@ -118,6 +112,13 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
         captureSession.addInput(deviceInput)
         captureSession.addOutput(photoOutput)
         captureSession.addOutput(videoOutput)
+        
+        let photoPreset = AVCaptureSession.Preset.photo
+
+        if captureSession.canSetSessionPreset(photoPreset) {
+            captureSession.sessionPreset = photoPreset
+            photoOutput.isLivePhotoCaptureEnabled = true
+        }
         
         videoPreviewLayer.session = captureSession
         videoPreviewLayer.videoGravity = .resizeAspectFill


### PR DESCRIPTION
Like discussed in my [issue](https://github.com/WeTransfer/WeScan/issues/291) there is a bug with preview of AVCaptureSession in iOS 14. ([Further details](https://openradar.appspot.com/FB8785505))