### PR TITLE
Restore support for devices which dont support Live Photo Capture

### DIFF
--- a/WeScan/Scan/CaptureSessionManager.swift
+++ b/WeScan/Scan/CaptureSessionManager.swift
@@ -117,7 +117,10 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
 
         if captureSession.canSetSessionPreset(photoPreset) {
             captureSession.sessionPreset = photoPreset
-            photoOutput.isLivePhotoCaptureEnabled = true
+            
+            if photoOutput.isLivePhotoCaptureSupported {
+                photoOutput.isLivePhotoCaptureEnabled = true
+            }
         }
         
         videoPreviewLayer.session = captureSession


### PR DESCRIPTION
Today I was able to test on old devices (iPhone 6s and prior).
The app crashes on those devices, when following code is executed:
`photoOutput.isLivePhotoCaptureEnabled = true`

This can only be set, after the support for this feature was checked.
I apologize for the inconvenience.