### PR TITLE
Call startRunning on a background thread

### DIFF
--- a/Sources/WeScan/Scan/CaptureSessionManager.swift
+++ b/Sources/WeScan/Scan/CaptureSessionManager.swift
@@ -141,7 +141,7 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
 
         switch authorizationStatus {
         case .authorized:
-            DispatchQueue.main.async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 self.captureSession.startRunning()
             }
             isDetecting = true


### PR DESCRIPTION
Let me post this unsolicited PR for your consideration, as I have seen bad performance (brief app freeze) when using this library in my app.

This is recommended, see https://developer.apple.com/documentation/avfoundation/avcapturesession

<img width="857" alt="start_running" src="https://user-images.githubusercontent.com/213249/228623078-1b246851-e372-4d9f-8af8-9cc8f2a8d0ff.png">
