### PR TITLE
modified to run captureSession.startRunning() on a background thread

### DIFF
--- a/Sources/WeScan/Scan/CaptureSessionManager.swift
+++ b/Sources/WeScan/Scan/CaptureSessionManager.swift
@@ -149,14 +149,13 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
             }
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: { [weak self] granted in
-                if granted {
-                    DispatchQueue.main.async {
-                        self?.start()
-                    }
-                } else {
-                    DispatchQueue.main.async {
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    if granted {
+                        self.start()
+                    } else {
                         let error = ImageScannerControllerError.authorization
-                        self?.delegate?.captureSessionManager(self!, didFailWithError: error)
+                        self.delegate?.captureSessionManager(self, didFailWithError: error)
                     }
                 }
             })

--- a/Sources/WeScan/Scan/CaptureSessionManager.swift
+++ b/Sources/WeScan/Scan/CaptureSessionManager.swift
@@ -144,7 +144,8 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 self?.captureSession.startRunning()
                 DispatchQueue.main.async {
-                    self?.isDetecting = true
+                    guard let self = self else { return }
+                    self.isDetecting = true
                 }
             }
         case .notDetermined:
@@ -161,8 +162,9 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
             })
         default:
             DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 let error = ImageScannerControllerError.authorization
-                self?.delegate?.captureSessionManager(self!, didFailWithError: error)
+                self.delegate?.captureSessionManager(self, didFailWithError: error)
             }
         }
     }

--- a/Sources/WeScan/Scan/CaptureSessionManager.swift
+++ b/Sources/WeScan/Scan/CaptureSessionManager.swift
@@ -141,19 +141,30 @@ final class CaptureSessionManager: NSObject, AVCaptureVideoDataOutputSampleBuffe
 
         switch authorizationStatus {
         case .authorized:
-            DispatchQueue.main.async {
-                self.captureSession.startRunning()
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.captureSession.startRunning()
+                DispatchQueue.main.async {
+                    self?.isDetecting = true
+                }
             }
-            isDetecting = true
         case .notDetermined:
-            AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: { _ in
-                DispatchQueue.main.async { [weak self] in
-                    self?.start()
+            AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: { [weak self] granted in
+                if granted {
+                    DispatchQueue.main.async {
+                        self?.start()
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        let error = ImageScannerControllerError.authorization
+                        self?.delegate?.captureSessionManager(self!, didFailWithError: error)
+                    }
                 }
             })
         default:
-            let error = ImageScannerControllerError.authorization
-            delegate?.captureSessionManager(self, didFailWithError: error)
+            DispatchQueue.main.async { [weak self] in
+                let error = ImageScannerControllerError.authorization
+                self?.delegate?.captureSessionManager(self!, didFailWithError: error)
+            }
         }
     }
 


### PR DESCRIPTION
It is more robust in thread management, ensuring that the start of the capture session does not block the main thread and that UI updates are performed on the main thread. Additionally, it carefully manages memory by using [weak self] to avoid retained cycles.